### PR TITLE
bugfix - better behavior of legacy client CLI when a static API key is set

### DIFF
--- a/src/planet_auth/auth.py
+++ b/src/planet_auth/auth.py
@@ -21,7 +21,9 @@ from planet_auth.auth_client import AuthClient, AuthClientConfig
 from planet_auth.credential import Credential
 from planet_auth.request_authenticator import CredentialRequestAuthenticator
 from planet_auth.storage_utils import ObjectStorageProvider
+from planet_auth.logging.auth_logger import getAuthLogger
 
+auth_logger = getAuthLogger()
 
 # class AuthClientContextException(AuthException):
 #     def __init__(self, **kwargs):
@@ -53,6 +55,8 @@ class Auth:
         Create a new auth container object with the specified auth components.
         Users should use one of the more friendly static initializer methods.
         """
+        auth_logger.debug(msg=f"Initializing Auth Context. Profile: {profile_name} ; Type: {type(auth_client).__name__} ; Token file: {token_file_path}")
+
         self._auth_client = auth_client
         self._request_authenticator = request_authenticator
         self._token_file_path = token_file_path

--- a/src/planet_auth/auth.py
+++ b/src/planet_auth/auth.py
@@ -55,7 +55,9 @@ class Auth:
         Create a new auth container object with the specified auth components.
         Users should use one of the more friendly static initializer methods.
         """
-        auth_logger.debug(msg=f"Initializing Auth Context. Profile: {profile_name} ; Type: {type(auth_client).__name__} ; Token file: {token_file_path}")
+        auth_logger.debug(
+            msg=f"Initializing Auth Context. Profile: {profile_name} ; Type: {type(auth_client).__name__} ; Token file: {token_file_path}"
+        )
 
         self._auth_client = auth_client
         self._request_authenticator = request_authenticator

--- a/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
+++ b/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
@@ -37,9 +37,9 @@ def _check_client_type_pllegacy(ctx):
 
 
 def _check_client_type_pllegacy_or_apikey(ctx):
-    if not (isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient)
-            or
-            isinstance(ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient)
+    if not (
+        isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient)
+        or isinstance(ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient)
     ):
         raise click.ClickException(
             "This command can only be used with "
@@ -47,6 +47,7 @@ def _check_client_type_pllegacy_or_apikey(ctx):
             "type auth profiles. "
             f'The current profile "{ctx.obj["AUTH"].profile_name()}" is of type "{ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
         )
+
 
 @click.group("legacy", invoke_without_command=True)
 @click.pass_context

--- a/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
+++ b/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
@@ -20,19 +20,33 @@ from planet_auth import (
     FileBackedPlanetLegacyApiKey,
     PlanetLegacyAuthClient,
     PlanetLegacyAuthClientConfig,
+    StaticApiKeyAuthClient,
+    StaticApiKeyAuthClientConfig,
 )
 
 from .options import opt_password, opt_sops, opt_username, opt_yes_no
 from .util import recast_exceptions_to_click, post_login_cmd_helper
 
 
-def _check_client_type(ctx):
+def _check_client_type_pllegacy(ctx):
     if not isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient):
         raise click.ClickException(
             f'"legacy" auth commands can only be used with "{PlanetLegacyAuthClientConfig.meta()["client_type"]}" type auth profiles.'
             f' The current profile "{ctx.obj["AUTH"].profile_name()}" is of type "{ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
         )
 
+
+def _check_client_type_pllegacy_or_apikey(ctx):
+    if not (isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient)
+            or
+            isinstance(ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient)
+    ):
+        raise click.ClickException(
+            "This command can only be used with "
+            f'"{PlanetLegacyAuthClientConfig.meta()["client_type"]}" or "{StaticApiKeyAuthClientConfig.meta()["client_type"]}" '
+            "type auth profiles. "
+            f'The current profile "{ctx.obj["AUTH"].profile_name()}" is of type "{ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
+        )
 
 @click.group("legacy", invoke_without_command=True)
 @click.pass_context
@@ -44,7 +58,7 @@ def cmd_pllegacy(ctx):
         click.echo(ctx.get_help())
         sys.exit(0)
 
-    _check_client_type(ctx)
+    _check_client_type_pllegacy(ctx)
 
 
 @cmd_pllegacy.command("login")
@@ -57,7 +71,7 @@ def cmd_pllegacy_login(ctx, username, password, sops, yes):
     """
     Perform an initial login using Planet's legacy authentication interfaces.
     """
-    _check_client_type(ctx)
+    _check_client_type_pllegacy(ctx)
     current_auth_context = ctx.obj["AUTH"]
     current_auth_context.login(
         allow_tty_prompt=True,
@@ -75,10 +89,26 @@ def cmd_pllegacy_print_api_key(ctx):
     """
     Show the API Key used by the currently selected authentication profile.
     """
-    _check_client_type(ctx)
+    # We also support StaticApiKeyAuthClient in some cases where the user
+    # directly provides an API key.  Such clients can use the legacy API
+    # key, but lack the ability to obtain one.  This helps in our transition
+    # away from the legacy auth protocol.
+    _check_client_type_pllegacy_or_apikey(ctx)
+
+    # Since API keys are static, we support them in the client config
+    # and not just in the token file.
+    if isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient):
+        api_key = ctx.obj["AUTH"].auth_client().config().legacy_api_key()
+        if api_key:
+            print(api_key)
+            return
+    if isinstance(ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient):
+        api_key = ctx.obj["AUTH"].auth_client().config().api_key()
+        if api_key:
+            print(api_key)
+            return
+
     saved_token = FileBackedPlanetLegacyApiKey(api_key_file=ctx.obj["AUTH"].token_file_path())
-    # Not using object print for API keys printing. We don't want object quoting and escaping.
-    # print_obj(saved_token.legacy_api_key())
     print(saved_token.legacy_api_key())
 
 
@@ -89,6 +119,6 @@ def cmd_pllegacy_print_access_token(ctx):
     """
     Show the legacy JWT currently held by the selected authentication profile.
     """
-    _check_client_type(ctx)
+    _check_client_type_pllegacy(ctx)
     saved_token = FileBackedPlanetLegacyApiKey(api_key_file=ctx.obj["AUTH"].token_file_path())
     print(saved_token.legacy_jwt())

--- a/src/planet_auth_utils/plauth_factory.py
+++ b/src/planet_auth_utils/plauth_factory.py
@@ -258,7 +258,7 @@ class PlanetAuthFactory:
         parameters set by the user, environment variables, configuration files, or values
         hard-coded by the application developer, and the number of possibilities rises.
 
-        This helper function is provided to help build applications achieve a consistent
+        This helper function is provided to help build applications with a consistent
         user experience when sharing auth context with the CLI.  This function
         does not support using custom storage providers at this time.
 

--- a/src/planet_auth_utils/plauth_factory.py
+++ b/src/planet_auth_utils/plauth_factory.py
@@ -110,6 +110,7 @@ class PlanetAuthFactory:
             profile_name=normalized_selected_profile, overide_path=token_file_opt, save_token_file=save_token_file  # type: ignore
         )
 
+        auth_logger.debug(msg=f"Initializing Auth from profile {normalized_selected_profile}")
         return Auth.initialize_from_config(
             client_config=auth_client_config,
             token_file=token_file_path,
@@ -143,6 +144,7 @@ class PlanetAuthFactory:
             profile_name=adhoc_profile_name, overide_path=token_file_opt, save_token_file=save_token_file
         )
 
+        auth_logger.debug(msg=f"Initializing Auth for service account {m2m_realm_name}:{client_id}")
         plauth_context = Auth.initialize_from_config_dict(
             client_config=constructed_client_config_dict,
             token_file=token_file_path,
@@ -169,6 +171,7 @@ class PlanetAuthFactory:
             profile_name=profile_name, overide_path=None, save_token_file=save_token_file
         )
 
+        auth_logger.debug(msg="Initializing Auth from provided configuration")
         plauth_context = Auth.initialize_from_config_dict(
             client_config=client_config,
             initial_token_data=initial_token_data,
@@ -216,6 +219,7 @@ class PlanetAuthFactory:
             "bearer_token_prefix": PlanetLegacyRequestAuthenticator.TOKEN_PREFIX,
         }
         adhoc_profile_name = "_PL_API_KEY"
+        auth_logger.debug(msg="Initializing Auth from API key")
         plauth_context = Auth.initialize_from_config_dict(
             client_config=constructed_client_config_dict,
             token_file=None,
@@ -249,18 +253,19 @@ class PlanetAuthFactory:
         Between built-in profiles to interactively login users, customer or third party
         registered OAuth clients and corresponding custom profiles that may be saved on disk,
         OAuth service account profiles, and static API keys, there are a number of
-        ways to configure how an application build with this library should authenticate
-        requests made to the service.  Add to this, configration may come from explict
-        parameters set by the user, environment variables, or configuration files, and the
-        number of possibilities rises.
+        ways to configure how an application built with this library should authenticate
+        requests made to the service.  Add to this configration may come from explict
+        parameters set by the user, environment variables, configuration files, or values
+        hard-coded by the application developer, and the number of possibilities rises.
 
-        This helper function is provided to help build applications with a consistent
+        This helper function is provided to help build applications achieve a consistent
         user experience when sharing auth context with the CLI.  This function
-        does not at this time support using custom storage providers.
+        does not support using custom storage providers at this time.
 
-        Arguments to this function are taken to be explicitly set by the user, and are
-        given the highest priority.  Internally, the priority used for the source of
-        any particular configuration values is, from highest to lowest priority, as follows:
+        Arguments to this function are taken to be explicitly set by the user or
+        application developer, and are given the highest priority.  Internally, the
+        priority used for the source of any particular configuration values is, from
+        highest to lowest priority, as follows:
             - Arguments to this function.
             - Environment variables.
             - Values from configuration file.


### PR DESCRIPTION
bugfix - better behavior of legacy client CLI when a static API key is set. 
Support static API keys is something we should do to help unset legacy auth protocols before we fully sunset API keys.