### PR TITLE
Beta feedback 1 - login command ergonomics

### DIFF
--- a/src/planet_auth_utils/commands/cli/main.py
+++ b/src/planet_auth_utils/commands/cli/main.py
@@ -71,6 +71,8 @@ def cmd_plauth(ctx, loglevel, auth_profile):
     ctx.obj["AUTH"] = PlanetAuthFactory.initialize_auth_client_context(
         auth_profile_opt=auth_profile,
         # token_file_opt=token_file,
+        use_env=True,
+        use_configfile=True,
     )
 
 
@@ -151,16 +153,16 @@ def cmd_plauth_reset():
 @cmd_plauth.command("login")
 @opt_open_browser()
 @opt_qr_code()
-@opt_scope()
-@opt_audience()
-@opt_organization()
-@opt_project()
-@opt_profile()
-@opt_client_id()
-@opt_client_secret()
-@opt_api_key()
-@opt_username()
-@opt_password()
+@opt_scope(envvar=None)
+@opt_audience(envvar=None)
+@opt_organization(envvar=None)
+@opt_project(envvar=None)
+@opt_profile(envvar=None)
+@opt_client_id(envvar=None)
+@opt_client_secret(envvar=None)
+@opt_api_key(envvar=None)
+@opt_username(envvar=None)
+@opt_password(envvar=None)
 @opt_sops()
 @opt_yes_no()
 @click.pass_context
@@ -207,6 +209,10 @@ def cmd_plauth_login(
         auth_api_key_opt=auth_api_key,
         # auth_username_opt=auth_username,
         # auth_password_opt=auth_password,
+        use_env=False,
+        use_configfile=False,
+        # TODO: save extras / project / org / scope
+        #  (or, should we leave such advanced cases for the oauth specific login command?)
     )
 
     print(f"Logging in with authentication profile {override_auth_context.profile_name()}...")

--- a/src/planet_auth_utils/commands/cli/options.py
+++ b/src/planet_auth_utils/commands/cli/options.py
@@ -14,7 +14,7 @@
 
 import click
 import pathlib
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from planet_auth_utils.constants import EnvironmentVariables
 
@@ -25,7 +25,7 @@ _click_option_decorator_type = Callable[..., Any]
 # TODO: Should we make "required" param universal for all options?
 #     Maybe rather than being so prescriptive, we pass **kwargs to click options?
 def opt_api_key(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_API_KEY
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_API_KEY
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an API key
@@ -48,7 +48,7 @@ def opt_api_key(
 
 
 def opt_audience(
-    default=None, hidden: bool = False, required=False, envvar: str = EnvironmentVariables.AUTH_AUDIENCE
+    default=None, hidden: bool = False, required=False, envvar: Optional[str] = EnvironmentVariables.AUTH_AUDIENCE
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an OAuth token audience for the
@@ -76,7 +76,7 @@ def opt_audience(
 
 
 def opt_client_id(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_CLIENT_ID
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_CLIENT_ID
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an OAuth client ID.
@@ -99,7 +99,7 @@ def opt_client_id(
 
 
 def opt_client_secret(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_CLIENT_SECRET
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_CLIENT_SECRET
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an OAuth client secret.
@@ -122,7 +122,7 @@ def opt_client_secret(
 
 
 def opt_extra(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_EXTRA
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_EXTRA
 ) -> _click_option_decorator_type:
     """
     Click option for specifying extra options.
@@ -169,7 +169,7 @@ def opt_human_readable(default=False, hidden: bool = False) -> _click_option_dec
 
 
 def opt_issuer(
-    default=None, hidden: bool = False, required=False, envvar: str = EnvironmentVariables.AUTH_ISSUER
+    default=None, hidden: bool = False, required=False, envvar: Optional[str] = EnvironmentVariables.AUTH_ISSUER
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an OAuth token issuer for the
@@ -194,7 +194,7 @@ def opt_issuer(
 
 
 def opt_loglevel(
-    default="INFO", hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_LOGLEVEL
+    default="INFO", hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_LOGLEVEL
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a log level.
@@ -257,7 +257,7 @@ def opt_open_browser(default=True, hidden: bool = False) -> _click_option_decora
 
 
 def opt_organization(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_ORGANIZATION
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_ORGANIZATION
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an Organization.
@@ -287,7 +287,7 @@ def opt_organization(
 #         lib also handles things like browser interaction this is not entirely easy to abstract
 #         away.
 def opt_password(
-    default=None, hidden: bool = True, envvar: str = EnvironmentVariables.AUTH_PASSWORD
+    default=None, hidden: bool = True, envvar: Optional[str] = EnvironmentVariables.AUTH_PASSWORD
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a password for the
@@ -311,7 +311,7 @@ def opt_password(
 
 
 def opt_profile(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_PROFILE
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_PROFILE
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an auth profile for the
@@ -336,7 +336,7 @@ def opt_profile(
 
 
 def opt_project(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_PROJECT
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_PROJECT
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a project ID.
@@ -397,7 +397,7 @@ def opt_refresh(default=True, hidden: bool = False) -> _click_option_decorator_t
 
 
 def opt_token(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_TOKEN
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_TOKEN
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a token literal.
@@ -421,7 +421,7 @@ def opt_token(
 
 
 def opt_scope(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_SCOPE
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_SCOPE
 ) -> _click_option_decorator_type:
     """
     Click option for specifying an OAuth token scope for the
@@ -468,7 +468,7 @@ def opt_sops(default=False, hidden: bool = False) -> _click_option_decorator_typ
 
 
 def opt_token_file(
-    default=None, hidden: bool = False, envvar: str = EnvironmentVariables.AUTH_TOKEN_FILE
+    default=None, hidden: bool = False, envvar: Optional[str] = EnvironmentVariables.AUTH_TOKEN_FILE
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a token file location for the
@@ -492,7 +492,7 @@ def opt_token_file(
 
 
 def opt_username(
-    default=None, hidden: bool = True, envvar: str = EnvironmentVariables.AUTH_USERNAME
+    default=None, hidden: bool = True, envvar: Optional[str] = EnvironmentVariables.AUTH_USERNAME
 ) -> _click_option_decorator_type:
     """
     Click option for specifying a username for the

--- a/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
+++ b/src/planet_auth_utils/commands/cli/planet_legacy_auth_cmd.py
@@ -16,6 +16,7 @@ import click
 import sys
 
 from planet_auth import (
+    Auth,
     AuthException,
     FileBackedPlanetLegacyApiKey,
     PlanetLegacyAuthClient,
@@ -23,29 +24,41 @@ from planet_auth import (
     StaticApiKeyAuthClient,
     StaticApiKeyAuthClientConfig,
 )
+from planet_auth_utils.plauth_factory import PlanetAuthFactory
 
-from .options import opt_password, opt_sops, opt_username, opt_yes_no
+from .options import (
+    # opt_api_key,
+    opt_password,
+    opt_profile,
+    opt_sops,
+    opt_username,
+    opt_yes_no,
+)
 from .util import recast_exceptions_to_click, post_login_cmd_helper
 
 
-def _check_client_type_pllegacy(ctx):
-    if not isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient):
+def _check_client_type_pllegacy(plauth_context: Auth):
+    if not isinstance(plauth_context.auth_client(), PlanetLegacyAuthClient):
         raise click.ClickException(
             f'"legacy" auth commands can only be used with "{PlanetLegacyAuthClientConfig.meta()["client_type"]}" type auth profiles.'
-            f' The current profile "{ctx.obj["AUTH"].profile_name()}" is of type "{ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
+            f' The current profile "{plauth_context.profile_name()}" is of type "{plauth_context.auth_client()._auth_client_config.meta()["client_type"]}".'
         )
 
 
-def _check_client_type_pllegacy_or_apikey(ctx):
+def _check_client_type_pllegacy_for_click_ctx(click_ctx):
+    _check_client_type_pllegacy(click_ctx.obj["AUTH"])
+
+
+def _check_client_type_pllegacy_or_apikey_for_click_ctx(click_ctx):
     if not (
-        isinstance(ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient)
-        or isinstance(ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient)
+        isinstance(click_ctx.obj["AUTH"].auth_client(), PlanetLegacyAuthClient)
+        or isinstance(click_ctx.obj["AUTH"].auth_client(), StaticApiKeyAuthClient)
     ):
         raise click.ClickException(
             "This command can only be used with "
             f'"{PlanetLegacyAuthClientConfig.meta()["client_type"]}" or "{StaticApiKeyAuthClientConfig.meta()["client_type"]}" '
             "type auth profiles. "
-            f'The current profile "{ctx.obj["AUTH"].profile_name()}" is of type "{ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
+            f'The current profile "{click_ctx.obj["AUTH"].profile_name()}" is of type "{click_ctx.obj["AUTH"].auth_client()._auth_client_config.meta()["client_type"]}".'
         )
 
 
@@ -59,29 +72,48 @@ def cmd_pllegacy(ctx):
         click.echo(ctx.get_help())
         sys.exit(0)
 
-    _check_client_type_pllegacy(ctx)
-
 
 @cmd_pllegacy.command("login")
-@opt_password(hidden=False)
-@opt_username(hidden=False)
+@opt_profile(envvar=None)
+@opt_password(hidden=False, envvar=None)
+@opt_username(hidden=False, envvar=None)
+# @opt_api_key(hidden=False, envvar=None)
 @opt_sops()
 @opt_yes_no()
 @click.pass_context
 @recast_exceptions_to_click(AuthException, FileNotFoundError)
-def cmd_pllegacy_login(ctx, username, password, sops, yes):
+def cmd_pllegacy_login(ctx, auth_profile, username, password, sops, yes):
     """
     Perform an initial login using Planet's legacy authentication interfaces.
     """
-    _check_client_type_pllegacy(ctx)
-    current_auth_context = ctx.obj["AUTH"]
-    current_auth_context.login(
+    # Like the root login command, the expected behavior of the legacy "login" command is
+    #   to do what it is told, not fall back to defaults and user prefs in unexpected ways.
+    #   We ignore env vars and the config file.
+    # root_cmd_auth_context = ctx.obj["AUTH"]
+    override_auth_context = PlanetAuthFactory.initialize_auth_client_context(
+        auth_profile_opt=auth_profile,
+        # TODO?: API Key isn't consumed yet to create a client config with an API key that retains
+        #  the knowledge that it was legacy protocol. We may never fix this as we are
+        #  retiring the old auth protocol.  This can be accomplished with the root
+        #  login command and an API key argument.
+        # auth_api_key_opt=auth_api_key,
+        # auth_username_opt=auth_username,
+        # auth_password_opt=auth_password,
+        use_env=False,
+        use_configfile=False,
+    )
+    _check_client_type_pllegacy(override_auth_context)
+    print(f"Logging in with authentication profile {override_auth_context.profile_name()}...")
+    override_auth_context.login(
         allow_tty_prompt=True,
         username=username,
         password=password,
+        # TODO: Should we support API key in login?
+        #    The main purpose of the legacy method login() is to get
+        #    the API key (and the JWT). Invoking login should force a login
     )
     print("Login succeeded.")  # Errors should throw.
-    post_login_cmd_helper(override_auth_context=current_auth_context, use_sops=sops, prompt_pre_selection=yes)
+    post_login_cmd_helper(override_auth_context=override_auth_context, use_sops=sops, prompt_pre_selection=yes)
 
 
 @cmd_pllegacy.command("print-api-key")
@@ -95,7 +127,7 @@ def cmd_pllegacy_print_api_key(ctx):
     # directly provides an API key.  Such clients can use the legacy API
     # key, but lack the ability to obtain one.  This helps in our transition
     # away from the legacy auth protocol.
-    _check_client_type_pllegacy_or_apikey(ctx)
+    _check_client_type_pllegacy_or_apikey_for_click_ctx(ctx)
 
     # Since API keys are static, we support them in the client config
     # and not just in the token file.
@@ -121,6 +153,6 @@ def cmd_pllegacy_print_access_token(ctx):
     """
     Show the legacy JWT currently held by the selected authentication profile.
     """
-    _check_client_type_pllegacy(ctx)
+    _check_client_type_pllegacy_for_click_ctx(ctx)
     saved_token = FileBackedPlanetLegacyApiKey(api_key_file=ctx.obj["AUTH"].token_file_path())
     print(saved_token.legacy_jwt())

--- a/src/planet_auth_utils/commands/cli/prompts.py
+++ b/src/planet_auth_utils/commands/cli/prompts.py
@@ -44,7 +44,7 @@ def prompt_and_change_user_default_profile_if_different(
         do_change_default = change_default_selection
     else:
         do_change_default = False
-        if saved_profile_name != candidate_profile_name:
+        if str.lower(saved_profile_name) != str.lower(candidate_profile_name):
             # do_change_default = yes_no_dialog(
             #     title=f'Change user default {EnvironmentVariables.AUTH_PROFILE} saved in {config_file.path()}?',
             #     text=f'Current value and user default differ.\nDo you want to change the user default {EnvironmentVariables.AUTH_PROFILE} from "{saved_profile_name}" to "{candidate_profile_name}"?',

--- a/src/planet_auth_utils/constants.py
+++ b/src/planet_auth_utils/constants.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from planet_auth_utils.builtins import Builtins
 
 
@@ -29,7 +31,7 @@ class EnvironmentVariables:
     """
 
     @staticmethod
-    def _namespace_variable(undecorated_variable: str):
+    def _namespace_variable(undecorated_variable: Optional[str]):
         """
         Decorate the variable name with a namespace.
         This is done so that multiple applications may use
@@ -37,7 +39,7 @@ class EnvironmentVariables:
         """
 
         namespace = Builtins.namespace()
-        if namespace:
+        if namespace and undecorated_variable:
             return f"{namespace.upper()}_{undecorated_variable}"
         return undecorated_variable
 

--- a/src/planet_auth_utils/plauth_factory.py
+++ b/src/planet_auth_utils/plauth_factory.py
@@ -243,6 +243,8 @@ class PlanetAuthFactory:
         # TODO?: initial_token_data: dict = None,
         save_token_file: bool = True,
         save_profile_config: bool = False,
+        use_env: bool = True,
+        use_configfile: bool = True,
         # Not supporting custom storage providers at this time.
         # The preferred behavior of Profiles with custom storage providers is TBD.
         # storage_provider: Optional[ObjectStorageProvider] = None,
@@ -312,6 +314,8 @@ class PlanetAuthFactory:
             save_token_file: Whether to save the access token to disk.  If `False`, in-memory
                 operation will be used, and login sessions will not be persisted locally.
             save_profile_config: Whether to save the profile configuration to disk.
+            use_env: Whether to use environment variables to determine configuration values.
+            use_configfile: Whether to use configuration files to determine configuration values.
         """
         #
         # Initialize from explicit user selected options
@@ -346,6 +350,8 @@ class PlanetAuthFactory:
         effective_user_selected_profile = user_config_file.effective_conf_value(
             config_key=EnvironmentVariables.AUTH_PROFILE,
             override_value=auth_profile_opt,
+            use_env=use_env,
+            use_configfile=use_configfile,
         )
         if effective_user_selected_profile:
             try:
@@ -365,10 +371,14 @@ class PlanetAuthFactory:
         effective_user_selected_client_id = user_config_file.effective_conf_value(
             config_key=EnvironmentVariables.AUTH_CLIENT_ID,
             override_value=auth_client_id_opt,
+            use_env=use_env,
+            use_configfile=use_configfile,
         )
         effective_user_selected_client_secret = user_config_file.effective_conf_value(
             config_key=EnvironmentVariables.AUTH_CLIENT_SECRET,
             override_value=auth_client_secret_opt,
+            use_env=use_env,
+            use_configfile=use_configfile,
         )
         if effective_user_selected_client_id and effective_user_selected_client_secret:
             return PlanetAuthFactory._init_context_from_oauth_svc_account(
@@ -383,6 +393,8 @@ class PlanetAuthFactory:
         effective_user_selected_api_key = user_config_file.effective_conf_value(
             config_key=EnvironmentVariables.AUTH_API_KEY,
             override_value=auth_api_key_opt,
+            use_env=use_env,
+            use_configfile=use_configfile,
         )
         if effective_user_selected_api_key:
             return PlanetAuthFactory._init_context_from_api_key(
@@ -390,9 +402,10 @@ class PlanetAuthFactory:
             )
 
         effective_user_selected_api_key = user_config_file.effective_conf_value(
-            config_key="key",  # For backwards compatibility
+            config_key="key",  # For backwards compatibility, we know the old SDK used this in json files.
             override_value=auth_api_key_opt,
             use_env=False,
+            use_configfile=use_configfile,
         )
         if effective_user_selected_api_key:
             return PlanetAuthFactory._init_context_from_api_key(


### PR DESCRIPTION
Change the root and auth method specific "login" commands to ignore of the automatic configuration from the environment.  If a user is invoking login, they mean it. 